### PR TITLE
check that exit was correctly called

### DIFF
--- a/t/03-set-failed.t
+++ b/t/03-set-failed.t
@@ -1,0 +1,22 @@
+use Test::More; # -*- mode: cperl -*-
+
+use lib qw(lib ../lib);
+
+my $exit_code;
+BEGIN {
+   *CORE::GLOBAL::exit = sub(;$) {
+       $exit_code = shift;
+   };
+}
+
+use GitHub::Actions;
+use Test::Output;
+
+sub verify_exit {
+   set_failed('This is the expected error message');
+}
+
+stdout_is(\&verify_exit,"::error::This is the expected error message\n", "Sets error correctly" );
+is $exit_code, 1, 'exit code was set correctly';
+
+done_testing;


### PR DESCRIPTION
The BEGIN block must be before we use the module in which we want to override it